### PR TITLE
Fix bug for first link to student detail page

### DIFF
--- a/client/app/main/dashboard/dashboard.controller.js
+++ b/client/app/main/dashboard/dashboard.controller.js
@@ -15,8 +15,7 @@ function DashboardCtrl($scope, Data, Auth, uiGridGroupingConstants) {
     displayName: 'Student Id',
     minWidth: 150,
     cellTemplate: '<div class="ui-grid-cell-contents">' +
-                  '<a ui-sref="student({id: ' +
-                  '\'{{row.entity.entries.student._id}}\'})">' +
+                  '<a href="/student/{{row.entity.entries.student._id}}">' +
                   '{{row.entity.entries.student.studentId}}</a>' +
                   '</div>'
   }, {


### PR DESCRIPTION
The first cell in the dashboard grid which contains a link
to the student detail page was not correctly creating the
url using ui-sref. Fixed by changing to using href.

@pdotsani 