### PR TITLE
Refactor DataService to expose instance arrays

### DIFF
--- a/client/app/main/admin/admin.controller.js
+++ b/client/app/main/admin/admin.controller.js
@@ -4,6 +4,7 @@ var app = angular.module('app');
 
 function AdminCtrl($scope, Auth, Data, User, School, Modal, ROLES) {
   $scope.roles = ROLES.slice(0, ROLES.indexOf(Auth.getCurrentUser().role) + 1);
+  $scope.data = Data;
 
   // Users
 
@@ -62,8 +63,8 @@ function AdminCtrl($scope, Auth, Data, User, School, Modal, ROLES) {
       return;
     }
     var updateFn = function() {
-      User.updateRole({id: user._id}, {role: role})
-        .$promise.then(function(updatedUser) {
+      User.updateRole({id: user._id}, {role: role}).$promise
+        .then(function(updatedUser) {
           _.assign(user, updatedUser);
         });
     };
@@ -75,8 +76,8 @@ function AdminCtrl($scope, Auth, Data, User, School, Modal, ROLES) {
       return;
     }
     var updateFn = function() {
-      User.updateAssignment({id: user._id}, {assignment: assignment})
-        .$promise.then(function() {
+      User.updateAssignment({id: user._id}, {assignment: assignment}).$promise
+        .then(function() {
           user.assignment = assignment;
         });
     };
@@ -110,13 +111,13 @@ function AdminCtrl($scope, Auth, Data, User, School, Modal, ROLES) {
 
   $scope.schoolGridOptions.onRegisterApi = function(gridApi) {
     $scope.schoolGridOptions = gridApi;
-    $scope.schoolGridOptions.data = Data.schools();
+    $scope.schoolGridOptions.data = $scope.data.schools;
   };
 
   $scope.addSchool = function() {
     var addSchoolFn = function(model) {
-      return School.save({}, model, function(school) {
-        Data.schools().push(school);
+      return School.save({}, model, function() {
+        Data.refreshSchools();
       });
     };
     Modal.form('Add New School', 'app/main/admin/partial/modal.add-school.html',
@@ -126,11 +127,17 @@ function AdminCtrl($scope, Auth, Data, User, School, Modal, ROLES) {
   $scope.deleteSchool = function(school) {
     var deleteSchoolFn = function() {
       School.remove({id: school._id}).$promise.then(function() {
-        _.pull(Data.schools(), school);
+        _.pull($scope.data.schools, school);
       });
     };
     Modal.confirm.delete(deleteSchoolFn)(school.name);
   };
+
+  $scope.$watch('data.schools', function(newSchools, oldSchools) {
+    if (newSchools !== oldSchools) {
+      $scope.schoolGridOptions.data = newSchools;
+    }
+  });
 }
 
 app.controller('AdminCtrl', AdminCtrl);

--- a/client/app/main/dashboard/dashboard.controller.js
+++ b/client/app/main/dashboard/dashboard.controller.js
@@ -3,6 +3,7 @@
 var app = angular.module('app');
 
 function DashboardCtrl($scope, Data, Auth, uiGridGroupingConstants) {
+  $scope.data = Data;
   $scope.studentGridOptions = {
     enableSorting: true,
     enableGridMenu: true,
@@ -68,8 +69,14 @@ function DashboardCtrl($scope, Data, Auth, uiGridGroupingConstants) {
 
   $scope.studentGridOptions.onRegisterApi = function(gridApi) {
     $scope.studentGridApi = gridApi;
-    $scope.studentGridOptions.data = Data.entries();
+    $scope.studentGridOptions.data = $scope.data.entries;
   };
+
+  $scope.$watch('data.entries', function(newEntries, oldEntries) {
+    if (newEntries !== oldEntries) {
+      $scope.studentGridOptions.data = newEntries;
+    }
+  });
 
   $scope.letters = 45;
   $scope.calls = 3;

--- a/client/app/main/main.controller.js
+++ b/client/app/main/main.controller.js
@@ -2,33 +2,9 @@
 
 var app = angular.module('app');
 
-function MainCtrl($scope, AbsenceRecord, Auth, Data, School, Sidebar) {
+function MainCtrl($scope, Data, Sidebar) {
   $scope.sidebar = Sidebar;
-  var user = Auth.getCurrentUser();
-  switch (user.role) {
-    case 'teacher':
-      if (user.assignment) {
-        School.get({id: user.assignment._id}).$promise
-          .then(function(school) {
-            Data.setSchools([school]);
-          });
-        AbsenceRecord.school({selector: user.assignment._id}).$promise
-          .then(function(entries) {
-            Data.setEntries(entries);
-          });
-      }
-      break;
-    case 'manager':
-    case 'admin':
-    case 'super':
-      School.list().$promise.then(function(schools) {
-        Data.setSchools(schools);
-      });
-      AbsenceRecord.list().$promise.then(function(entries) {
-        Data.setEntries(entries);
-      });
-      break;
-  }
+  Data.initialize();
 }
 
 app.controller('MainCtrl', MainCtrl);

--- a/client/app/main/pdf-upload/pdf-upload.controller.js
+++ b/client/app/main/pdf-upload/pdf-upload.controller.js
@@ -6,7 +6,7 @@ app.controller('PDFUploadCtrl',
   function($scope, AbsenceRecord, Auth, Data, Upload) {
     $scope.forms = {};
     $scope.isUploaded = false;
-    $scope.schools = Data.schools();
+    $scope.schools = Data.schools;
 
     if (Auth.getCurrentUser().role === 'teacher') {
       $scope.defaultSchool = Auth.getCurrentUser().assignment;
@@ -32,6 +32,7 @@ app.controller('PDFUploadCtrl',
         $scope.data.upload.message = 'Upload Confirmed!';
         $scope.result.data = {};
         $scope.isUploaded = false;
+        Data.refreshEntries();
       }, function(err) {
         console.log(err);
         $scope.data.upload.message = 'Confirmation Error: ' + err;

--- a/client/components/absence-record/absence-record.service.js
+++ b/client/components/absence-record/absence-record.service.js
@@ -6,18 +6,11 @@ app.factory('AbsenceRecord', function($resource) {
   return $resource('/api/absence-records/:id/:controller/:selector', {
     id: '@_id'
   }, {
-    list: {
+    listCurrent: {
       method: 'GET',
       isArray: true,
       params: {
-        controller: 'schools'
-      }
-    },
-    school: {
-      method: 'GET',
-      isArray: true,
-      params: {
-        controller: 'schools'
+        controller: 'current'
       }
     }
   });

--- a/client/components/data/data.service.js
+++ b/client/components/data/data.service.js
@@ -2,23 +2,17 @@
 
 var app = angular.module('app');
 
-app.service('Data', function() {
-  var _schools = [];
-  var _entries = [];
-
-  this.schools = function() {
-    return _schools;
-  };
-  this.setSchools = function(schools) {
-    _schools.length = 0;
-    [].push.apply(_schools, schools);
+app.service('Data', function(School, AbsenceRecord) {
+  this.refreshSchools = function() {
+    this.schools = School.query();
   };
 
-  this.entries = function() {
-    return _entries;
+  this.refreshEntries = function() {
+    this.entries = AbsenceRecord.listCurrent();
   };
-  this.setEntries = function(entries) {
-    _entries.length = 0;
-    [].push.apply(_entries, entries);
+
+  this.initialize = function() {
+    this.refreshSchools();
+    this.refreshEntries();
   };
 });

--- a/client/components/school/school.service.js
+++ b/client/components/school/school.service.js
@@ -6,10 +6,6 @@ app.factory('School', function($resource) {
   return $resource('/api/schools/:id/:controller', {
     id: '@_id'
   }, {
-    list: {
-      method: 'GET',
-      isArray: true
-    },
     students: {
       method: 'GET',
       isArray: true,

--- a/server/api/absence-record/index.js
+++ b/server/api/absence-record/index.js
@@ -11,14 +11,9 @@ router.post('/',
   auth.authorizeSchool('body'),
   controller.create);
 
-router.get('/schools',
-  auth.hasRole('manager'),
-  controller.allSchools);
-
-router.get('/schools/:schoolId',
+router.get('/current',
   auth.hasRole('teacher'),
-  auth.authorizeSchool('params'),
-  controller.school);
+  controller.current);
 
 router.get('/', auth.hasRole('manager'), controller.index);
 router.get('/:id', auth.hasRole('teacher'), controller.show);

--- a/server/api/school/index.js
+++ b/server/api/school/index.js
@@ -6,7 +6,7 @@ var auth = require('../../auth/auth.service');
 
 var router = express.Router();
 
-router.get('/', auth.hasRole('manager'), controller.index);
+router.get('/', auth.hasRole('teacher'), controller.index);
 router.get('/students', auth.hasRole('manager'), controller.students);
 // TODO: Add "assignment" authorization check.
 router.get('/:id', auth.hasRole('teacher'), controller.show);

--- a/server/api/school/school.controller.js
+++ b/server/api/school/school.controller.js
@@ -5,12 +5,20 @@ var School = require('./school.model');
 var Student = require('../student/student.model');
 
 /**
- * Get list of schools
- * restriction: 'manager'
+ * Get a list of schools
+ * restriction: 'teacher'
+ *
+ * Returns a list of schools based on the req user role:
+ * - teachers will get a list containing the assignment school
+ * - manager+ will get a list of all schools
  */
 exports.index = function(req, res) {
-  School.find(function(err, schools) {
-    if (err) { return handleError(res, err); }
+  var options = {};
+  if (req.user.role === 'teacher') {
+    options._id = req.user.assignment._id;
+  }
+  School.find(options).exec(function(err, schools) {
+    if (err) return handleError(res, err);
     return res.status(200).json(schools);
   });
 };


### PR DESCRIPTION
Resolves #129

- Instead of having private vars in the Data service,
  expose arrays carrying the instances queried from the server.
- Move logic of which schools and entries to request from client
  to server to create a single initialization path.
- For now just request a full refresh of entries when uploading
  a pdf with absence data.

@pdotsani 