### PR TITLE
Prevent server from crashing after invalid pdf uploads

### DIFF
--- a/client/app/main/pdf-upload/pdf-upload.controller.js
+++ b/client/app/main/pdf-upload/pdf-upload.controller.js
@@ -73,20 +73,29 @@ function PDFUploadCtrl($scope, AbsenceRecord, Auth, School, Upload, toastr) {
       $scope.forms.upload.file.$setValidity('server', true);
       delete $scope.data.upload.fileError;
 
-      $scope.upload($scope.data.upload.file).then(function(res) {
-        if (res.status === 200) {
-          $scope.data.upload = {school: $scope.defaultSchool};
-          $scope.data.upload.message =
-            'Confirm you want to upload the following...';
-          $scope.result = res;
-          $scope.forms.upload.$setPristine();
-          $scope.isUploaded = true;
-        } else {
+      $scope.upload($scope.data.upload.file)
+        .then(function(res) {
+          if (res.status === 200) {
+            $scope.data.upload = {school: $scope.defaultSchool};
+            $scope.data.upload.message =
+              'Confirm you want to upload the following...';
+            $scope.result = res;
+            $scope.forms.upload.$setPristine();
+            $scope.isUploaded = true;
+          } else {
+            $scope.forms.upload.file.$setValidity('server', false);
+            $scope.data.upload.fileError = res.status + ': ' + res.statusText;
+          }
+          $scope.data.upload.processingUpload = false;
+        })
+        .catch(function(err) {
           $scope.forms.upload.file.$setValidity('server', false);
-          $scope.data.upload.fileError = res.status + ': ' + res.statusText;
-        }
-        $scope.data.upload.processingUpload = false;
-      });
+          $scope.data.upload.fileError = 
+            'Error uploading PDF... Refresh page to try again.' + 
+            '{ ' + err.status + ': ' + err.statusText + ' }';
+          $scope.data.upload.processingUpload = false;
+          // TODO: Find way to reset form so user doesn't have to refresh page
+        });
     }
   };
 }

--- a/client/app/main/pdf-upload/pdf-upload.controller.js
+++ b/client/app/main/pdf-upload/pdf-upload.controller.js
@@ -92,7 +92,7 @@ function PDFUploadCtrl($scope, AbsenceRecord, Auth, School, Upload, toastr) {
           $scope.forms.upload.file.$setValidity('server', false);
           $scope.data.upload.fileError = 
             'Error uploading PDF... Refresh page to try again.' + 
-            '{ ' + err.status + ': ' + err.statusText + ' }';
+            ' { ' + err.status + ': ' + err.statusText + ' }';
           $scope.data.upload.processingUpload = false;
           // TODO: Find way to reset form so user doesn't have to refresh page
         });

--- a/server/api/pdf/pdf.controller.js
+++ b/server/api/pdf/pdf.controller.js
@@ -20,21 +20,28 @@ function splitRowChunks(rows) {
   return _.zip.apply(null, propertyArrays);
 }
 
+//Checks if value is a valid number, including 0 
+function isValNum(num){
+  return (num === undefined || isNaN(num)) && num !== 0;
+}
+
 function parseStudent(arr) {
   var result = {};
   var names = arr[0][0].split(', ');
   result.student = {
-    lastName: names[0],
-    firstName: names[1],
-    studentId: arr[0][1]
+    lastName: _.isString(names[0]) ? names[0] : undefined,
+    firstName: _.isString(names[1]) ? names[1] : undefined,
+    studentId: _.isString(arr[0][1]) ? arr[0][1] : undefined
   };
   result.entry = {
-    absences: +arr[1][1],
-    tardies: +arr[2][1],
-    present: +arr[3][1],
-    enrolled: +arr[4][1]
+    absences: (isValNum(+arr[1][1])) ? NaN : +arr[1][1],
+    tardies: (isValNum(+arr[2][1])) ? NaN : +arr[2][1],
+    present: (isValNum(+arr[3][1])) ? NaN : +arr[3][1],
+    enrolled: (isValNum(+arr[4][1])) ? NaN : +arr[4][1]
   };
   result.schoolYear = arr[5][1].replace(/\s/g, '');
+  // TODO: Use undefined or NaN data in fields to provide user with
+  // reason why PDF did not upload.
   return result;
 }
 
@@ -79,9 +86,14 @@ function createInterventions(entry, prevEntry, school, schoolYear) {
 function parsePDF(buffer, school, date, res) {
   pdf2table.parse(buffer, function(err, rows) {
     if (err) return handleError(res, err);
-    // TODO: Try catch for failure to parse.
-    var students = studentDataArrays(rows).map(parseStudent);
-    // This will throw if no students, add guard statement (invalid upload?).
+    var students;
+    try {
+      students = studentDataArrays(rows).map(parseStudent);
+    }
+    // Try catch for failure to parse.
+    catch(err) {
+      return res.status(500).json(err);
+    }
     var schoolYear = students[0].schoolYear;
     previousRecord(school.id, schoolYear).then(function(prev) {
       var idToPrev = _.keyBy((prev || {}).entries, 'student.studentId');
@@ -110,7 +122,7 @@ function parsePDF(buffer, school, date, res) {
       result.schoolId = school.id;
       result.date = date;
       res.status(200).json(result);
-    });
+    })
   });
 }
 

--- a/server/api/pdf/pdf.controller.js
+++ b/server/api/pdf/pdf.controller.js
@@ -20,28 +20,21 @@ function splitRowChunks(rows) {
   return _.zip.apply(null, propertyArrays);
 }
 
-//Checks if value is a valid number, including 0 
-function isValNum(num){
-  return (num === undefined || isNaN(num)) && num !== 0;
-}
-
 function parseStudent(arr) {
   var result = {};
   var names = arr[0][0].split(', ');
   result.student = {
-    lastName: _.isString(names[0]) ? names[0] : undefined,
-    firstName: _.isString(names[1]) ? names[1] : undefined,
-    studentId: _.isString(arr[0][1]) ? arr[0][1] : undefined
+    lastName:     names[0], 
+    firstName:    names[1], 
+    studentId:    arr[0][1]
   };
   result.entry = {
-    absences: (isValNum(+arr[1][1])) ? NaN : +arr[1][1],
-    tardies: (isValNum(+arr[2][1])) ? NaN : +arr[2][1],
-    present: (isValNum(+arr[3][1])) ? NaN : +arr[3][1],
-    enrolled: (isValNum(+arr[4][1])) ? NaN : +arr[4][1]
+    absences:     +arr[1][1],
+    tardies:      +arr[2][1],
+    present:      +arr[3][1],
+    enrolled:     +arr[4][1]
   };
   result.schoolYear = arr[5][1].replace(/\s/g, '');
-  // TODO: Use undefined or NaN data in fields to provide user with
-  // reason why PDF did not upload.
   return result;
 }
 
@@ -122,7 +115,7 @@ function parsePDF(buffer, school, date, res) {
       result.schoolId = school.id;
       result.date = date;
       res.status(200).json(result);
-    })
+    });
   });
 }
 


### PR DESCRIPTION
resolves #109

@dting 

create try and catch statements to handle PDF upload errors
throw 500 error and inform user to reset browser to try PDF upload again
minor fixes caught by running grunt
ensure fields created in parseStudent function have a value of undefined or NaN if none available