### PR TITLE
Fix a couple layout bugs with school reports

### DIFF
--- a/client/app/main/school-reports/school-reports.html
+++ b/client/app/main/school-reports/school-reports.html
@@ -1,7 +1,7 @@
-<div class="school-reports">
-  <div class="heading row">
+<div class="school-reports row">
+  <div class="heading">
     <h3>At Risk Chronic Absenteeism Rate
-      <div class="badge">{{curCARCount}}</div>
+      <span class="badge">{{curCARCount}}</span>
     </h3>
   </div>
   <div class="student-list">
@@ -15,7 +15,7 @@
   </div>
   <div class="heading row">
     <h3>Chronically Absent
-      <div class="badge">{{arcaCount * 100 | number: 1}}&#37;</div>
+      <span class="badge">{{arcaCount}}</span>
     </h3>
   </div>
   <div class="student-list">


### PR DESCRIPTION
@pdotsani 

- Make tables fill entire layout.
- Remove percentage conversion of arca in the badge since
  it is just a count not a percentage.