### PR TITLE
Fix intervention and outreach sorting in Student view.

### DIFF
--- a/client/app/main/student/partial/interventions.html
+++ b/client/app/main/student/partial/interventions.html
@@ -1,7 +1,6 @@
 <tab-heading tabs="tabs"></tab-heading>
 <div class="interventions">
-  <div ng-repeat="intervention in interventions | orderBy:intervention.triggerDate:true"
-    class="intervention-widget">
+  <div ng-repeat="intervention in interventions" class="intervention-widget">
     <div class="title" ng-class="{'action-required':!intervention.actionDate}">
       <h4>{{intervention.type}} #{{intervention.tier}}
         <small>({{intervention.absences}} Absences)</small>

--- a/client/app/main/student/partial/outreaches.html
+++ b/client/app/main/student/partial/outreaches.html
@@ -1,6 +1,6 @@
 <tab-heading tabs="tabs" menu-items="menuItems"></tab-heading>
 <div class="outreaches">
-  <div ng-repeat="outreach in outreaches | orderBy:createdDate:true"
+  <div ng-repeat="outreach in outreaches"
     class="outreach-widget"
     ng-class="{archived: outreach.archived}"
     ng-if="!outreach.archived || showArchived">

--- a/client/app/main/student/student.controller.js
+++ b/client/app/main/student/student.controller.js
@@ -166,7 +166,7 @@ function StudentOutreachesCtrl($scope, Outreach, Modal, toastr) {
         model.school = $scope.student.currentSchool._id;
         return Outreach.save({}, model, function(res) {
           $scope.$evalAsync(function() {
-            $scope.outreaches.push(res);
+            $scope.outreaches.unshift(res);
           });
         });
       };

--- a/server/api/student/student.controller.js
+++ b/server/api/student/student.controller.js
@@ -45,6 +45,7 @@ exports.show = function(req, res) {
       return Intervention
         .find({student: req.params.id})
         .populate('notes.user')
+        .sort({_id: -1})
         .exec();
     })
     .then(function(interventions) {
@@ -52,6 +53,7 @@ exports.show = function(req, res) {
       return Outreach
         .find({student: req.params.id})
         .populate('notes.user')
+        .sort({_id: -1})
         .exec();
     })
     .then(function(outreaches) {


### PR DESCRIPTION
Resolves #286.

Move sort to server using ._id to return the in the order the interventions were triggered or the outreaches were created.