### PR TITLE
Enable highcharts no data module.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -32,5 +32,15 @@
   },
   "resolutions": {
     "angular": ">=1.5.0"
+  },
+  "overrides": {
+    "highcharts": {
+      "main": [
+        "highcharts.js",
+        "highcharts-more.js",
+        "modules/exporting.js",
+        "modules/no-data-to-display.js"
+      ]
+    }
   }
 }

--- a/client/index.html
+++ b/client/index.html
@@ -87,6 +87,7 @@
 <script src="bower_components/highcharts/highcharts.js"></script>
 <script src="bower_components/highcharts/highcharts-more.js"></script>
 <script src="bower_components/highcharts/modules/exporting.js"></script>
+<script src="bower_components/highcharts/modules/no-data-to-display.js"></script>
 <script src="bower_components/highcharts-ng/dist/highcharts-ng.js"></script>
 <script src="bower_components/pdfjs-dist/build/pdf.js"></script>
 <script src="bower_components/angular-ui-router-default/angular-ui-router-default.js"></script>


### PR DESCRIPTION
Add overrides to bower.json to have grunt inject the desired module. This module will display a statement that there is no data when the server doesn't return data for the HighCharts.