### PR TITLE
Save currentSchool as an ObjectId instead of string.

### DIFF
--- a/server/api/absence-record/absence-record.controller.js
+++ b/server/api/absence-record/absence-record.controller.js
@@ -74,7 +74,7 @@ exports.create = function(req, res) {
   // Assign students to be created to validated school.
   _.forEach(newStudents, function(student) {
     _.defaults(student, studentDefaults);
-    student.currentSchool = req.school.id;
+    student.currentSchool = req.school._id;
   });
   var promise = createStudents(newStudents);
   promise.then(function(createdStudents) {


### PR DESCRIPTION
Resolves #398.