### PR TITLE
Create outreach summary grid service.

### DIFF
--- a/client/app/main/dashboard/dashboard.scss
+++ b/client/app/main/dashboard/dashboard.scss
@@ -36,6 +36,9 @@
     .grid {
       @extend %abs-fill-parent;
       border: none;
+      .withdrawn {
+        color: darkgrey;
+      }
     }
   }
 }

--- a/client/app/main/school/reports/outreach-summary/outreach-summary.controller.js
+++ b/client/app/main/school/reports/outreach-summary/outreach-summary.controller.js
@@ -2,8 +2,14 @@
 
 var app = angular.module('app');
 
-function OutreachSummaryCtrl($scope, $timeout, GridDefaults,
-  uiGridGroupingConstants, Student) {
+function OutreachSummaryCtrl($scope, $timeout, GridDefaults, Student) {
+  var totalsDefault = {
+    Phone: {count: 0, resolved: 0, outstanding: 0},
+    Letter: {count: 0, resolved: 0, outstanding: 0},
+    Home: {count: 0, resolved: 0, outstanding: 0},
+    SST: {count: 0, resolved: 0, outstanding: 0},
+    Court: {count: 0, resolved: 0, outstanding: 0}
+  };
   $scope.loading = true;
 
   $scope.gridOptions = GridDefaults.options();
@@ -12,145 +18,24 @@ function OutreachSummaryCtrl($scope, $timeout, GridDefaults,
     GridDefaults.colDefs.studentId(),
     GridDefaults.colDefs.firstName(),
     GridDefaults.colDefs.lastName(),
-    {
-      name: 'Phone.count',
-      displayName: 'Phone',
-      minWidth: 80,
-      type: 'number',
-      headerTooltip: 'Phone Calls',
-      treeAggregationType: uiGridGroupingConstants.aggregation.SUM
-    }, {
-      name: 'Phone.resolved',
-      displayName: 'Resolved',
-      minWidth: 80,
-      type: 'number',
-      headerTooltip: 'Phone Resolved',
-      treeAggregationType: uiGridGroupingConstants.aggregation.SUM,
-      visible: false
-    }, {
-      name: 'Phone.outstanding',
-      displayName: 'Outstanding',
-      minWidth: 80,
-      type: 'number',
-      headerTooltip: 'Phone Outstanding',
-      treeAggregationType: uiGridGroupingConstants.aggregation.SUM,
-      visible: false
-    }, {
-      name: 'Letter.count',
-      displayName: 'Letter',
-      minWidth: 80,
-      type: 'number',
-      headerTooltip: 'Letters Sent',
-      treeAggregationType: uiGridGroupingConstants.aggregation.SUM
-    }, {
-      name: 'Letter.resolved',
-      displayName: 'Resolved',
-      minWidth: 80,
-      type: 'number',
-      headerTooltip: 'Letter Resolved',
-      treeAggregationType: uiGridGroupingConstants.aggregation.SUM,
-      visible: false
-    }, {
-      name: 'Letter.outstanding',
-      displayName: 'Outstanding',
-      minWidth: 80,
-      type: 'number',
-      headerTooltip: 'Letter Outstanding',
-      treeAggregationType: uiGridGroupingConstants.aggregation.SUM,
-      visible: false
-    }, {
-      name: 'Home.count',
-      displayName: 'Home',
-      minWidth: 80,
-      type: 'number',
-      headerTooltip: 'Home Visits',
-      treeAggregationType: uiGridGroupingConstants.aggregation.SUM
-    }, {
-      name: 'Home.resolved',
-      displayName: 'Resolved',
-      minWidth: 80,
-      type: 'number',
-      headerTooltip: 'Home Resolved',
-      treeAggregationType: uiGridGroupingConstants.aggregation.SUM,
-      visible: false
-    }, {
-      name: 'Home.outstanding',
-      displayName: 'Outstanding',
-      minWidth: 80,
-      type: 'number',
-      headerTooltip: 'Home Outstanding',
-      treeAggregationType: uiGridGroupingConstants.aggregation.SUM,
-      visible: false
-    }, {
-      name: 'SST.count',
-      displayName: 'SST',
-      minWidth: 80,
-      type: 'number',
-      headerTooltip: 'SST Referrals',
-      treeAggregationType: uiGridGroupingConstants.aggregation.SUM
-    }, {
-      name: 'SST.resolved',
-      displayName: 'Resolved',
-      minWidth: 80,
-      type: 'number',
-      headerTooltip: 'SST Resolved',
-      treeAggregationType: uiGridGroupingConstants.aggregation.SUM,
-      visible: false
-    }, {
-      name: 'SST.outstanding',
-      displayName: 'Outstanding',
-      minWidth: 80,
-      type: 'number',
-      headerTooltip: 'SST Outstanding',
-      treeAggregationType: uiGridGroupingConstants.aggregation.SUM,
-      visible: false
-    }, {
-      name: 'Court.count',
-      displayName: 'Court',
-      minWidth: 80,
-      type: 'number',
-      headerTooltip: 'Court Referrals',
-      treeAggregationType: uiGridGroupingConstants.aggregation.SUM
-    }, {
-      name: 'Court.resolved',
-      displayName: 'Resolved',
-      minWidth: 80,
-      type: 'number',
-      headerTooltip: 'Court Resolved',
-      treeAggregationType: uiGridGroupingConstants.aggregation.SUM,
-      visible: false
-    }, {
-      name: 'Court.outstanding',
-      displayName: 'Outstanding',
-      minWidth: 80,
-      type: 'number',
-      headerTooltip: 'Court Outstanding',
-      treeAggregationType: uiGridGroupingConstants.aggregation.SUM,
-      visible: false
-    }, {
-      name: 'count',
-      displayName: 'Total',
-      minWidth: 80,
-      type: 'number',
-      headerTooltip: 'Total Outreaches',
-      treeAggregationType: uiGridGroupingConstants.aggregation.SUM
-    }, {
-      name: 'resolved',
-      displayName: 'Resolved',
-      minWidth: 80,
-      type: 'number',
-      headerTooltip: 'Resolved Outreaches',
-      treeAggregationType: uiGridGroupingConstants.aggregation.SUM,
-      visible: false
-    }, {
-      name: 'outstanding',
-      displayName: 'Outstanding',
-      minWidth: 80,
-      type: 'number',
-      headerTooltip: 'Outstanding Outreaches',
-      treeAggregationType: uiGridGroupingConstants.aggregation.SUM,
-      visible: false
-    },
+    GridDefaults.colDefs.outreach('Phone Call', 'count', true),
+    GridDefaults.colDefs.outreach('Phone Call', 'resolved'),
+    GridDefaults.colDefs.outreach('Phone Call', 'outstanding'),
+    GridDefaults.colDefs.outreach('Letter Sent', 'count', true),
+    GridDefaults.colDefs.outreach('Letter Sent', 'resolved'),
+    GridDefaults.colDefs.outreach('Letter Sent', 'outstanding'),
+    GridDefaults.colDefs.outreach('Home Visit', 'count', true),
+    GridDefaults.colDefs.outreach('Home Visit', 'resolved'),
+    GridDefaults.colDefs.outreach('Home Visit', 'outstanding'),
+    GridDefaults.colDefs.outreach('SST Referral', 'count', true),
+    GridDefaults.colDefs.outreach('SST Referral', 'resolved'),
+    GridDefaults.colDefs.outreach('SST Referral', 'outstanding'),
+    GridDefaults.colDefs.outreach('Court Referral', 'count', true),
+    GridDefaults.colDefs.outreach('Court Referral', 'resolved'),
+    GridDefaults.colDefs.outreach('Court Referral', 'outstanding'),
+    GridDefaults.colDefs.outreach('Total', 'count', true),
+    GridDefaults.colDefs.outreach('Total', 'resolved'),
+    GridDefaults.colDefs.outreach('Total', 'outstanding'),
     GridDefaults.colDefs.cfa(),
     GridDefaults.colDefs.withdrawn($scope)
   ];
@@ -168,13 +53,6 @@ function OutreachSummaryCtrl($scope, $timeout, GridDefaults,
         }
       }
     });
-    var totalsDefault = {
-      Phone: {count: 0, resolved: 0, outstanding: 0},
-      Letter: {count: 0, resolved: 0, outstanding: 0},
-      Home: {count: 0, resolved: 0, outstanding: 0},
-      SST: {count: 0, resolved: 0, outstanding: 0},
-      Court: {count: 0, resolved: 0, outstanding: 0}
-    };
     $scope.gridOptions.data = Student.outreachSummary();
     $scope.gridOptions.data.$promise.then(function(data) {
       // Convert counts array to object, generate total intervention property.
@@ -186,9 +64,11 @@ function OutreachSummaryCtrl($scope, $timeout, GridDefaults,
           })
           .defaults(totalsDefault)
           .value();
-        totals.count = _.sumBy(row.counts, 'count');
-        totals.resolved = _.sumBy(row.counts, 'resolved');
-        totals.outstanding = _.sumBy(row.counts, 'outstanding');
+        totals.Total = {
+          count: _.sumBy(row.counts, 'count'),
+          resolved: _.sumBy(row.counts, 'resolved'),
+          outstanding: _.sumBy(row.counts, 'outstanding')
+        };
         _.assign(row, totals);
       });
       // NOTE: Hack to default to expanded rows on initial load.

--- a/client/app/main/school/reports/outreach-summary/outreach-summary.controller.js
+++ b/client/app/main/school/reports/outreach-summary/outreach-summary.controller.js
@@ -2,84 +2,9 @@
 
 var app = angular.module('app');
 
-function OutreachSummaryCtrl($scope, $timeout, GridDefaults, Student) {
-  var totalsDefault = {
-    Phone: {count: 0, resolved: 0, outstanding: 0},
-    Letter: {count: 0, resolved: 0, outstanding: 0},
-    Home: {count: 0, resolved: 0, outstanding: 0},
-    SST: {count: 0, resolved: 0, outstanding: 0},
-    Court: {count: 0, resolved: 0, outstanding: 0}
-  };
+function OutreachSummaryCtrl($scope, $timeout, OutreachSummaryGrid) {
   $scope.loading = true;
-
-  $scope.gridOptions = GridDefaults.options();
-  $scope.gridOptions.columnDefs = [
-    GridDefaults.colDefs.school(),
-    GridDefaults.colDefs.studentId(),
-    GridDefaults.colDefs.firstName(),
-    GridDefaults.colDefs.lastName(),
-    GridDefaults.colDefs.outreach('Phone Call', 'count', true),
-    GridDefaults.colDefs.outreach('Phone Call', 'resolved'),
-    GridDefaults.colDefs.outreach('Phone Call', 'outstanding'),
-    GridDefaults.colDefs.outreach('Letter Sent', 'count', true),
-    GridDefaults.colDefs.outreach('Letter Sent', 'resolved'),
-    GridDefaults.colDefs.outreach('Letter Sent', 'outstanding'),
-    GridDefaults.colDefs.outreach('Home Visit', 'count', true),
-    GridDefaults.colDefs.outreach('Home Visit', 'resolved'),
-    GridDefaults.colDefs.outreach('Home Visit', 'outstanding'),
-    GridDefaults.colDefs.outreach('SST Referral', 'count', true),
-    GridDefaults.colDefs.outreach('SST Referral', 'resolved'),
-    GridDefaults.colDefs.outreach('SST Referral', 'outstanding'),
-    GridDefaults.colDefs.outreach('Court Referral', 'count', true),
-    GridDefaults.colDefs.outreach('Court Referral', 'resolved'),
-    GridDefaults.colDefs.outreach('Court Referral', 'outstanding'),
-    GridDefaults.colDefs.outreach('Total', 'count', true),
-    GridDefaults.colDefs.outreach('Total', 'resolved'),
-    GridDefaults.colDefs.outreach('Total', 'outstanding'),
-    GridDefaults.colDefs.cfa(),
-    GridDefaults.colDefs.withdrawn($scope)
-  ];
-  $scope.gridOptions.onRegisterApi = function(gridApi) {
-    $scope.gridApi = gridApi;
-    gridApi.edit.on.afterCellEdit($scope, function(row, colDef, n, o) {
-      if (n !== o) {
-        switch (colDef.name) {
-          case 'student.cfa':
-            Student.updateCFA(row.student);
-            break;
-          case 'student.withdrawn':
-            Student.updateWithdrawn(row.student);
-            break;
-        }
-      }
-    });
-    $scope.gridOptions.data = Student.outreachSummary();
-    $scope.gridOptions.data.$promise.then(function(data) {
-      // Convert counts array to object, generate total intervention property.
-      _.forEach(data, function(row) {
-        var totals = _(row.counts)
-          .keyBy('type')
-          .mapKeys(function(value, key) {
-            return key.split(' ')[0];
-          })
-          .defaults(totalsDefault)
-          .value();
-        totals.Total = {
-          count: _.sumBy(row.counts, 'count'),
-          resolved: _.sumBy(row.counts, 'resolved'),
-          outstanding: _.sumBy(row.counts, 'outstanding')
-        };
-        _.assign(row, totals);
-      });
-      // NOTE: Hack to default to expanded rows on initial load.
-      // https://github.com/angular-ui/ui-grid/issues/3841
-      $timeout(gridApi.treeBase.expandAllRows);
-      $scope.loading = false;
-    });
-  };
-  $scope.gridOptions.csvFileNameFn = function() {
-    return GridDefaults.datePrefix() + ' Outreach Summary.csv';
-  };
+  $scope.gridOptions = OutreachSummaryGrid.options($scope);
 
   $scope.$watch('showWithdrawn', function(n, o) {
     if (n !== o) {

--- a/client/app/main/school/reports/outreach-summary/outreach-summary.controller.js
+++ b/client/app/main/school/reports/outreach-summary/outreach-summary.controller.js
@@ -13,55 +13,183 @@ function OutreachSummaryCtrl($scope, $timeout, GridDefaults,
     GridDefaults.colDefs.firstName(),
     GridDefaults.colDefs.lastName(),
     {
-      name: 'totals.all',
+      name: 'Phone.count',
+      displayName: 'Phone',
+      minWidth: 80,
+      type: 'number',
+      headerTooltip: 'Phone Calls',
+      treeAggregationType: uiGridGroupingConstants.aggregation.SUM
+    }, {
+      name: 'Phone.resolved',
+      displayName: 'Resolved',
+      minWidth: 80,
+      type: 'number',
+      headerTooltip: 'Phone Resolved',
+      treeAggregationType: uiGridGroupingConstants.aggregation.SUM,
+      visible: false
+    }, {
+      name: 'Phone.outstanding',
+      displayName: 'Outstanding',
+      minWidth: 80,
+      type: 'number',
+      headerTooltip: 'Phone Outstanding',
+      treeAggregationType: uiGridGroupingConstants.aggregation.SUM,
+      visible: false
+    }, {
+      name: 'Letter.count',
+      displayName: 'Letter',
+      minWidth: 80,
+      type: 'number',
+      headerTooltip: 'Letters Sent',
+      treeAggregationType: uiGridGroupingConstants.aggregation.SUM
+    }, {
+      name: 'Letter.resolved',
+      displayName: 'Resolved',
+      minWidth: 80,
+      type: 'number',
+      headerTooltip: 'Letter Resolved',
+      treeAggregationType: uiGridGroupingConstants.aggregation.SUM,
+      visible: false
+    }, {
+      name: 'Letter.outstanding',
+      displayName: 'Outstanding',
+      minWidth: 80,
+      type: 'number',
+      headerTooltip: 'Letter Outstanding',
+      treeAggregationType: uiGridGroupingConstants.aggregation.SUM,
+      visible: false
+    }, {
+      name: 'Home.count',
+      displayName: 'Home',
+      minWidth: 80,
+      type: 'number',
+      headerTooltip: 'Home Visits',
+      treeAggregationType: uiGridGroupingConstants.aggregation.SUM
+    }, {
+      name: 'Home.resolved',
+      displayName: 'Resolved',
+      minWidth: 80,
+      type: 'number',
+      headerTooltip: 'Home Resolved',
+      treeAggregationType: uiGridGroupingConstants.aggregation.SUM,
+      visible: false
+    }, {
+      name: 'Home.outstanding',
+      displayName: 'Outstanding',
+      minWidth: 80,
+      type: 'number',
+      headerTooltip: 'Home Outstanding',
+      treeAggregationType: uiGridGroupingConstants.aggregation.SUM,
+      visible: false
+    }, {
+      name: 'SST.count',
+      displayName: 'SST',
+      minWidth: 80,
+      type: 'number',
+      headerTooltip: 'SST Referrals',
+      treeAggregationType: uiGridGroupingConstants.aggregation.SUM
+    }, {
+      name: 'SST.resolved',
+      displayName: 'Resolved',
+      minWidth: 80,
+      type: 'number',
+      headerTooltip: 'SST Resolved',
+      treeAggregationType: uiGridGroupingConstants.aggregation.SUM,
+      visible: false
+    }, {
+      name: 'SST.outstanding',
+      displayName: 'Outstanding',
+      minWidth: 80,
+      type: 'number',
+      headerTooltip: 'SST Outstanding',
+      treeAggregationType: uiGridGroupingConstants.aggregation.SUM,
+      visible: false
+    }, {
+      name: 'Court.count',
+      displayName: 'Court',
+      minWidth: 80,
+      type: 'number',
+      headerTooltip: 'Court Referrals',
+      treeAggregationType: uiGridGroupingConstants.aggregation.SUM
+    }, {
+      name: 'Court.resolved',
+      displayName: 'Resolved',
+      minWidth: 80,
+      type: 'number',
+      headerTooltip: 'Court Resolved',
+      treeAggregationType: uiGridGroupingConstants.aggregation.SUM,
+      visible: false
+    }, {
+      name: 'Court.outstanding',
+      displayName: 'Outstanding',
+      minWidth: 80,
+      type: 'number',
+      headerTooltip: 'Court Outstanding',
+      treeAggregationType: uiGridGroupingConstants.aggregation.SUM,
+      visible: false
+    }, {
+      name: 'count',
       displayName: 'Total',
       minWidth: 80,
+      type: 'number',
+      headerTooltip: 'Total Outreaches',
       treeAggregationType: uiGridGroupingConstants.aggregation.SUM
     }, {
-      name: 'totals["Phone Call"] || 0',
-      displayName: 'Calls',
-      minWidth: 100,
-      treeAggregationType: uiGridGroupingConstants.aggregation.SUM
+      name: 'resolved',
+      displayName: 'Resolved',
+      minWidth: 80,
+      type: 'number',
+      headerTooltip: 'Resolved Outreaches',
+      treeAggregationType: uiGridGroupingConstants.aggregation.SUM,
+      visible: false
     }, {
-      name: 'totals["Letter Sent"] || 0',
-      displayName: 'Letters',
-      minWidth: 100,
-      treeAggregationType: uiGridGroupingConstants.aggregation.SUM
-    }, {
-      name: 'totals["Home Visit"] || 0',
-      displayName: 'Visits',
-      minWidth: 100,
-      treeAggregationType: uiGridGroupingConstants.aggregation.SUM
-    }, {
-      name: 'totals["SST Referral"] || 0',
-      displayName: 'SST',
-      minWidth: 100,
-      treeAggregationType: uiGridGroupingConstants.aggregation.SUM
-    }, {
-      name: 'totals["Court Referral"] || 0',
-      displayName: 'Court',
-      minWidth: 100,
-      treeAggregationType: uiGridGroupingConstants.aggregation.SUM
+      name: 'outstanding',
+      displayName: 'Outstanding',
+      minWidth: 80,
+      type: 'number',
+      headerTooltip: 'Outstanding Outreaches',
+      treeAggregationType: uiGridGroupingConstants.aggregation.SUM,
+      visible: false
     },
+    GridDefaults.colDefs.cfa(),
     GridDefaults.colDefs.withdrawn($scope)
   ];
   $scope.gridOptions.onRegisterApi = function(gridApi) {
     $scope.gridApi = gridApi;
-    gridApi.edit.on.afterCellEdit($scope, function(rowEntity, colDef, n, o) {
+    gridApi.edit.on.afterCellEdit($scope, function(row, colDef, n, o) {
       if (n !== o) {
         switch (colDef.name) {
+          case 'student.cfa':
+            Student.updateCFA(row.student);
+            break;
           case 'student.withdrawn':
-            Student.updateWithdrawn(rowEntity.student);
+            Student.updateWithdrawn(row.student);
             break;
         }
       }
     });
+    var totalsDefault = {
+      Phone: {count: 0, resolved: 0, outstanding: 0},
+      Letter: {count: 0, resolved: 0, outstanding: 0},
+      Home: {count: 0, resolved: 0, outstanding: 0},
+      SST: {count: 0, resolved: 0, outstanding: 0},
+      Court: {count: 0, resolved: 0, outstanding: 0}
+    };
     $scope.gridOptions.data = Student.outreachSummary();
     $scope.gridOptions.data.$promise.then(function(data) {
-      // Convert counts array to object, generate total intervention property
+      // Convert counts array to object, generate total intervention property.
       _.forEach(data, function(row) {
-        row.totals = _(row.counts).keyBy('type').mapValues('count').value();
-        row.totals.all = _.sumBy(row.counts, 'count');
+        var totals = _(row.counts)
+          .keyBy('type')
+          .mapKeys(function(value, key) {
+            return key.split(' ')[0];
+          })
+          .defaults(totalsDefault)
+          .value();
+        totals.count = _.sumBy(row.counts, 'count');
+        totals.resolved = _.sumBy(row.counts, 'resolved');
+        totals.outstanding = _.sumBy(row.counts, 'outstanding');
+        _.assign(row, totals);
       });
       // NOTE: Hack to default to expanded rows on initial load.
       // https://github.com/angular-ui/ui-grid/issues/3841

--- a/client/app/main/school/reports/outreach-summary/outreach-summary.grid.service.js
+++ b/client/app/main/school/reports/outreach-summary/outreach-summary.grid.service.js
@@ -1,0 +1,82 @@
+'use strict';
+
+function OutreachSummaryGrid($timeout, GridDefaults, Student) {
+  var totalsDefault = {
+    Phone: {count: 0, resolved: 0, outstanding: 0},
+    Letter: {count: 0, resolved: 0, outstanding: 0},
+    Home: {count: 0, resolved: 0, outstanding: 0},
+    SST: {count: 0, resolved: 0, outstanding: 0},
+    Court: {count: 0, resolved: 0, outstanding: 0}
+  };
+
+  var columnDefs = [
+    GridDefaults.colDefs.school(),
+    GridDefaults.colDefs.studentId(),
+    GridDefaults.colDefs.firstName(),
+    GridDefaults.colDefs.lastName(),
+    GridDefaults.colDefs.outreach('Phone Call', 'count', true),
+    GridDefaults.colDefs.outreach('Phone Call', 'resolved'),
+    GridDefaults.colDefs.outreach('Phone Call', 'outstanding'),
+    GridDefaults.colDefs.outreach('Letter Sent', 'count', true),
+    GridDefaults.colDefs.outreach('Letter Sent', 'resolved'),
+    GridDefaults.colDefs.outreach('Letter Sent', 'outstanding'),
+    GridDefaults.colDefs.outreach('Home Visit', 'count', true),
+    GridDefaults.colDefs.outreach('Home Visit', 'resolved'),
+    GridDefaults.colDefs.outreach('Home Visit', 'outstanding'),
+    GridDefaults.colDefs.outreach('SST Referral', 'count', true),
+    GridDefaults.colDefs.outreach('SST Referral', 'resolved'),
+    GridDefaults.colDefs.outreach('SST Referral', 'outstanding'),
+    GridDefaults.colDefs.outreach('Court Referral', 'count', true),
+    GridDefaults.colDefs.outreach('Court Referral', 'resolved'),
+    GridDefaults.colDefs.outreach('Court Referral', 'outstanding'),
+    GridDefaults.colDefs.outreach('Total', 'count', true),
+    GridDefaults.colDefs.outreach('Total', 'resolved'),
+    GridDefaults.colDefs.outreach('Total', 'outstanding'),
+    GridDefaults.colDefs.cfa()
+  ];
+
+  function csvFileNameFn() {
+    return GridDefaults.datePrefix() + ' Outreach Summary.csv';
+  }
+
+  function reshape(data) {
+    // Convert counts array to object, generate total intervention property.
+    _.forEach(data, function(row) {
+      var totals = _(row.counts)
+        .keyBy('type')
+        .mapKeys(function(value, key) {
+          return key.split(' ')[0];
+        })
+        .defaults(totalsDefault)
+        .value();
+      totals.Total = {
+        count: _.sumBy(row.counts, 'count'),
+        resolved: _.sumBy(row.counts, 'resolved'),
+        outstanding: _.sumBy(row.counts, 'outstanding')
+      };
+      _.assign(row, totals);
+    });
+    return data;
+  }
+
+  this.options = function(scope) {
+    var gridOptions = _.merge(GridDefaults.options(), {
+      columnDefs: _.concat(columnDefs, [GridDefaults.colDefs.withdrawn(scope)]),
+      csvFileNameFn: csvFileNameFn
+    });
+    gridOptions.onRegisterApi = function(gridApi) {
+      gridApi.edit.on.afterCellEdit(scope, GridDefaults.afterCellEditFn(scope));
+      Student.outreachSummary().$promise.then(reshape).then(function(data) {
+        gridOptions.data = data;
+        // NOTE: Hack to default to expanded rows on initial load.
+        // https://github.com/angular-ui/ui-grid/issues/3841
+        $timeout(gridApi.treeBase.expandAllRows);
+        scope.loading = false;
+      });
+      scope.gridApi = gridApi;
+    };
+    return gridOptions;
+  };
+}
+
+angular.module('app').service('OutreachSummaryGrid', OutreachSummaryGrid);

--- a/client/app/main/school/reports/reports.controller.js
+++ b/client/app/main/school/reports/reports.controller.js
@@ -18,7 +18,7 @@ function SchoolReportsCtrl($scope) {
   }];
 
   $scope.menuItems = [{
-    text: ' Withdrawn Students',
+    text: 'Withdrawn Students',
     action: function() {
       $scope.showWithdrawn = !$scope.showWithdrawn;
     },

--- a/client/app/main/school/reports/reports.scss
+++ b/client/app/main/school/reports/reports.scss
@@ -19,6 +19,9 @@
       flex: 1;
       border: none;
       overflow-y: scroll;
+      .withdrawn {
+        color: darkgrey;
+      }
     }
   }
 }

--- a/client/components/grid-defaults/grid-defaults.record.row.html
+++ b/client/components/grid-defaults/grid-defaults.record.row.html
@@ -1,0 +1,8 @@
+<div
+  ng-repeat="(colRenderIndex, col) in colContainer.renderedColumns track by col.uid"
+  ui-grid-one-bind-id-grid="rowRenderIndex + '-' + col.uid + '-cell'"
+  class="ui-grid-cell"
+  ng-class="{ 'ui-grid-row-header-cell': col.isRowHeader, 'withdrawn': row.entity.student.withdrawn }"
+  role="{{col.isRowHeader ? 'rowheader' : 'gridcell'}}"
+  ui-grid-cell>
+</div>

--- a/client/components/grid-defaults/grid-defaults.service.js
+++ b/client/components/grid-defaults/grid-defaults.service.js
@@ -177,6 +177,7 @@ function GridDefaults($filter, $timeout, gridUtil, Student, AbsenceRecord,
               break;
             case 'student.withdrawn':
               Student.updateWithdrawn(row.student);
+              scope.$broadcast('withdrawn-updated');
               break;
           }
         }

--- a/client/components/grid-defaults/grid-defaults.service.js
+++ b/client/components/grid-defaults/grid-defaults.service.js
@@ -86,6 +86,18 @@ function GridDefaults($filter, $timeout, gridUtil, Student, AbsenceRecord,
       width: 125
     };
   };
+  colDefs.outreach = function(name, type, visible) {
+    var firstWord = name.split(' ')[0];
+    return {
+      name: firstWord + '.' + type,
+      displayName: type === 'count' ? firstWord : _.capitalize(type),
+      minWidth: 80,
+      type: 'number',
+      headerTooltip: name + ' ' + _.capitalize(type),
+      treeAggregationType: uiGridGroupingConstants.aggregation.SUM,
+      visible: !!visible
+    };
+  };
 
   function options() {
     return {

--- a/client/components/grid-defaults/grid-defaults.service.js
+++ b/client/components/grid-defaults/grid-defaults.service.js
@@ -1,6 +1,6 @@
 'use strict';
 
-function GridDefaults($filter, $timeout, Student, AbsenceRecord,
+function GridDefaults($filter, $timeout, gridUtil, Student, AbsenceRecord,
   uiGridGroupingConstants, uiGridExporterService) {
   var colDefs = {};
   colDefs.school = function(name) {
@@ -72,6 +72,7 @@ function GridDefaults($filter, $timeout, Student, AbsenceRecord,
           return cellValue === false;
         }
       },
+      treeAggregationType: uiGridGroupingConstants.aggregation.SUM,
       visible: false
     };
   };
@@ -114,6 +115,7 @@ function GridDefaults($filter, $timeout, Student, AbsenceRecord,
         return value;
       },
       csvFileNameFn: scope.csvFileNameFn,
+      rowTemplate: 'components/grid-defaults/grid-defaults.record.row.html',
       columnDefs: [
         colDefs.school(),
         colDefs.studentId(),

--- a/client/components/heading/heading.html
+++ b/client/components/heading/heading.html
@@ -10,7 +10,11 @@
       <i class="fa fa-caret-right fa-lg" ng-class="{'fa-rotate-90': isopen}"></i>
     </button>
     <ul uib-dropdown-menu role="menu">
-      <li role="menuitem" ng-repeat="item in menuItems" ng-click="item.action()">
+      <li role="menuitem"
+        ng-repeat="item in menuItems"
+        ng-click="item.action()"
+        class="dropdown-menu-item"
+        ng-class="{disabled: item.disabledFn && item.disabledFn()}">
         <hr class="menu-separator" ng-if="item.separator"/>
         <a href>
           <i class="fa" ng-class="item.icon || item.iconFn()" ng-if="item.icon || item.iconFn"></i>

--- a/client/components/heading/heading.scss
+++ b/client/components/heading/heading.scss
@@ -49,6 +49,14 @@
     top: 48px;
     left: auto;
     right: 0;
+    .dropdown-menu-item {
+      i {
+        margin-right: 5px;
+      }
+      &.disabled {
+        pointer-events: none;
+      }
+    }
   }
   .menu-separator {
     margin-top: 5px;

--- a/client/components/student/student.service.js
+++ b/client/components/student/student.service.js
@@ -104,10 +104,11 @@ app.factory('Student', function($resource, toastr) {
         });
       }
     },
-    outreachCounts: function() {
-      return resource.outreachCounts().$promise.then(function(counts) {
-        return _(counts).keyBy('_id').mapValues('count').value();
-      });
+    outreachCounts: function(withdrawn) {
+      return resource.outreachCounts({withdrawn: !!withdrawn})
+        .$promise.then(function(counts) {
+          return _(counts).keyBy('_id').mapValues('count').value();
+        });
     },
     interventionSummary: resource.interventionSummary,
     outreachSummary: resource.outreachSummary,

--- a/client/components/student/student.service.js
+++ b/client/components/student/student.service.js
@@ -44,6 +44,10 @@ app.factory('Student', function($resource, toastr) {
         controller: 'outreach-summary'
       },
       isArray: true
+    },
+    batchUpdate: {
+      method: 'PUT',
+      isArray: true
     }
   });
 
@@ -106,6 +110,20 @@ app.factory('Student', function($resource, toastr) {
       });
     },
     interventionSummary: resource.interventionSummary,
-    outreachSummary: resource.outreachSummary
+    outreachSummary: resource.outreachSummary,
+    batchUpdate: function(studentIds, controller, value) {
+      return resource.batchUpdate({controller: controller}, {
+        studentIds: studentIds,
+        value: value
+      }, function(updatedStudents) {
+        toastr.success(
+          controller.toUpperCase() + ' set to: ' + value,
+          updatedStudents.length + ' students updated.');
+        return updatedStudents;
+      }, function(err) {
+        toastr.error(err);
+        return err;
+      });
+    }
   };
 });

--- a/client/components/tab-heading/tab-heading.scss
+++ b/client/components/tab-heading/tab-heading.scss
@@ -30,6 +30,14 @@
     line-height: $cfa-unit;
     font-weight: 200;
   }
+  .dropdown-menu-item {
+    i {
+      margin-right: 5px;
+    }
+    &.disabled {
+      pointer-events: none;
+    }
+  }
   .navbar-collapse {
     background-color: $light-sky-blue;
   }

--- a/client/index.html
+++ b/client/index.html
@@ -123,6 +123,7 @@
 <script src="app/main/school/reports/intervention-summary/intervention-summary.controller.js"></script>
 <script src="app/main/school/reports/intervention-summary/intervention-summary.js"></script>
 <script src="app/main/school/reports/outreach-summary/outreach-summary.controller.js"></script>
+<script src="app/main/school/reports/outreach-summary/outreach-summary.grid.service.js"></script>
 <script src="app/main/school/reports/outreach-summary/outreach-summary.js"></script>
 <script src="app/main/school/reports/reports.controller.js"></script>
 <script src="app/main/school/reports/reports.js"></script>

--- a/server/api/student/index.js
+++ b/server/api/student/index.js
@@ -6,6 +6,7 @@ var auth = require('../../auth/auth.service');
 
 var router = express.Router();
 var authorize = [auth.hasRole('teacher'), auth.student];
+var authorizeBatch = [auth.hasRole('teacher'), auth.studentBatch];
 
 router.get('/outreach-counts',
   auth.hasRole('teacher'),
@@ -23,6 +24,11 @@ router.get('/:studentId', authorize, controller.show);
 router.put('/:studentId/iep', authorize, controller.updateIEP);
 router.put('/:studentId/cfa', authorize, controller.updateCFA);
 router.put('/:studentId/withdrawn', authorize, controller.updateWithdrawn);
+
+router.put('/:field',
+  authorizeBatch,
+  controller.validateBatchUpdate,
+  controller.batchUpdate);
 
 router.use('/:studentId/interventions', require('./intervention'));
 router.use('/:studentId/outreaches', require('./outreach'));

--- a/server/api/student/student.controller.js
+++ b/server/api/student/student.controller.js
@@ -160,23 +160,49 @@ exports.outreachCounts = function(req, res) {
  * - manager+ will get outreach summary for all schools
  */
 exports.outreachSummary = function(req, res) {
+  var match = {};
+  if (req.user.role === 'teacher') {
+    match.school = req.user.assignment;
+  }
   var pipeline = [{
+    $match: match
+  }, {
+    $group: {
+      _id: {school: '$school', schoolYear: '$schoolYear'},
+      outreaches: {$push: '$$ROOT'}
+    }
+  }, {
+    $sort: {'_id.schoolYear': -1}
+  }, {
+    $unwind: '$outreaches'
+  }, {
+    $project: {
+      _id: false,
+      student: '$outreaches.student',
+      type: '$outreaches.type',
+      school: '$outreaches.school',
+      resolved: {$cond: [{$gt: ['$outreaches.actionDate', 0]}, 1, 0]}
+    }
+  }, {
     $group: {
       _id: {student: '$student', type: '$type', school: '$school'},
-      count: {$sum: 1}
+      count: {$sum: 1},
+      resolved: {$sum: '$resolved'}
     }
   }, {
     $group: {
       _id: '$_id.student',
       school: {$first: '$_id.school'},
-      counts: {$push: {type: '$_id.type', count: '$count'}}
+      counts: {$push: {
+        type: '$_id.type',
+        count: '$count',
+        resolved: '$resolved',
+        outstanding: {$subtract: ['$count', '$resolved']}
+      }}
     }
   }, {
-    $project: {_id: 0, student: '$_id', counts: 1, school: 1}
+    $project: {_id: false, student: '$_id', counts: 1, school: 1}
   }];
-  if (req.user.role === 'teacher') {
-    pipeline.unshift({$match: {school: req.user.assignment}});
-  }
   Outreach.aggregate(pipeline, function(err, results) {
     if (err) handleError(res, err);
     Outreach.populate(results, [{


### PR DESCRIPTION
Move a lot of the logic out of the controller into a service to keep the controller thin.

This also allows us to define the majority of the defaults once, when the service is created, instead of every time the controller is made.