### PR TITLE
Fix occassional visualization sizing bug

### DIFF
--- a/client/app/main/visualization/visualization.html
+++ b/client/app/main/visualization/visualization.html
@@ -12,7 +12,7 @@
       </ui-select>
     </div>
   </div>
-  <div class="comparison" ng-show="loaded">
+  <div class="comparison" ng-if="loaded">
     <heading text="'CFA Enrollment Comparison'"></heading>
     <div class="charts">
       <highchart config="cfaConfig" class="chart"></highchart>


### PR DESCRIPTION
Resolves #419.

It appears the bug is from using ng-show. The main difference is
the graph is just hidden using show and removed and added using if.
I'm still not completely sure what the cause is or how to even force
a redraw, but switching to ng-if seems to fix the problem.