### PR TITLE
Make grid columns resizable.

### DIFF
--- a/client/app/app.js
+++ b/client/app/app.js
@@ -14,6 +14,7 @@ var app = angular.module('app', [
   'ui.grid.exporter',
   'ui.grid.grouping',
   'ui.grid.pinning',
+  'ui.grid.resizeColumns',
   'ui.grid.selection',
   'ui.router',
   'ui.router.default',

--- a/client/app/main/admin/admin.html
+++ b/client/app/main/admin/admin.html
@@ -4,8 +4,9 @@
     <div ui-grid="userGridOptions"
       ui-grid-auto-resize
       ui-grid-edit
-      ui-grid-pinning
       ui-grid-exporter
+      ui-grid-pinning
+      ui-grid-resize-columns
       id="user-grid"
       class="grid">
     </div>

--- a/client/app/main/dashboard/dashboard.html
+++ b/client/app/main/dashboard/dashboard.html
@@ -42,10 +42,11 @@
     <grid-status loading="loading" grid-api="gridApi"></grid-status>
     <div ui-grid="gridOptions"
       ui-grid-auto-resize
-      ui-grid-selection
-      ui-grid-grouping
       ui-grid-edit
       ui-grid-exporter
+      ui-grid-grouping
+      ui-grid-resize-columns
+      ui-grid-selection
       class="grid"></div>
   </div>
 </section>

--- a/client/app/main/records/upload/upload.controller.js
+++ b/client/app/main/records/upload/upload.controller.js
@@ -120,6 +120,7 @@ function UploadCtrl($scope, PDF, AbsenceRecord, Auth, School, toastr) {
       prevRecord.missingEntries || []);
     var studentIdToPrevEntry = _.keyBy(combinedEntries, 'student.studentId');
     var record = groupByType(partialRecord.students, studentIdToPrevEntry);
+    record.schoolYear = partialRecord.schoolYear;
     _.forEach(record.updates || [], function(update) {
       var entry = update.entry;
       var prevEntry = studentIdToPrevEntry[update.student.studentId];
@@ -153,6 +154,7 @@ function UploadCtrl($scope, PDF, AbsenceRecord, Auth, School, toastr) {
       .mapValues('student._id')
       .value();
     var record = groupByType(partialRecord.students, studentIdToId);
+    record.schoolYear = partialRecord.schoolYear;
     _.forEach(record.updates || [], function(update) {
       var entry = update.entry;
       entry.student = studentIdToId[update.student.studentId];
@@ -176,11 +178,9 @@ function UploadCtrl($scope, PDF, AbsenceRecord, Auth, School, toastr) {
       var entry = create.entry;
       entry.tardiesDelta = entry.tardies;
       entry.absencesDelta = entry.absences;
-      entry.outreaches =
-        createOutreaches(entry, {}, school, partialRecord.schoolYear);
+      entry.outreaches = createOutreaches(entry, {}, school, record.schoolYear);
     });
     record.schoolId = school._id;
-    record.schoolYear = partialRecord.schoolYear;
     record.previousRecordId = previousRecord.recordId;
     return record;
   }

--- a/client/app/main/school/reports/intervention-summary/intervention-summary.grid.service.js
+++ b/client/app/main/school/reports/intervention-summary/intervention-summary.grid.service.js
@@ -9,7 +9,8 @@ function InterventionSummaryGrid($timeout, GridDefaults, Student) {
     {
       name: 'type',
       displayName: 'Type',
-      minWidth: 150,
+      headerTooltip: 'Type',
+      minWidth: 54 * 3,
       grouping: {groupPriority: 1},
       sort: {priority: 0, direction: 'asc'}
     }

--- a/client/app/main/school/reports/reports.table.html
+++ b/client/app/main/school/reports/reports.table.html
@@ -2,9 +2,10 @@
   <grid-status loading="loading" grid-api="gridApi"></grid-status>
   <div ui-grid="gridOptions"
     ui-grid-auto-resize
-    ui-grid-selection
-    ui-grid-grouping
     ui-grid-edit
     ui-grid-exporter
+    ui-grid-grouping
+    ui-grid-resize-columns
+    ui-grid-selection
     class="grid"></div>
 </div>

--- a/client/components/grid-defaults/grid-defaults.service.js
+++ b/client/components/grid-defaults/grid-defaults.service.js
@@ -7,7 +7,9 @@ function GridDefaults($filter, $timeout, Student, AbsenceRecord,
     return {
       name: name || 'school.name',
       displayName: 'School Name',
-      minWidth: 150,
+      headerTooltip: 'School Name',
+      minWidth: 54 * 4,
+      width: 54 * 6,
       grouping: {groupPriority: 0},
       sort: {priority: 0, direction: 'asc'}
     };
@@ -18,7 +20,8 @@ function GridDefaults($filter, $timeout, Student, AbsenceRecord,
     return {
       name: 'student.studentId',
       displayName: 'Student Id',
-      minWidth: 150,
+      headerTooltip: 'Student Id',
+      minWidth: 54 * 2,
       cellTemplate: 'components/grid-defaults/grid-defaults.student-id.html'
     };
   };
@@ -26,14 +29,16 @@ function GridDefaults($filter, $timeout, Student, AbsenceRecord,
     return {
       name: name || 'student.firstName',
       displayName: 'First Name',
-      minWidth: 150
+      headerTooltip: 'First Name',
+      minWidth: 54 * 3
     };
   };
   colDefs.lastName = function(name) {
     return {
       name: name || 'student.lastName',
       displayName: 'Last Name',
-      minWidth: 150
+      headerTooltip: 'Last Name',
+      minWidth: 54 * 3
     };
   };
   colDefs.iep = function(name) {
@@ -42,7 +47,8 @@ function GridDefaults($filter, $timeout, Student, AbsenceRecord,
       displayName: 'IEP',
       enableCellEdit: true,
       type: 'boolean',
-      width: 100,
+      headerTooltip: 'IEP',
+      minWidth: 54,
       treeAggregationType: uiGridGroupingConstants.aggregation.SUM
     };
   };
@@ -52,7 +58,8 @@ function GridDefaults($filter, $timeout, Student, AbsenceRecord,
       displayName: 'CFA',
       enableCellEdit: true,
       type: 'boolean',
-      width: 100,
+      headerTooltip: 'CFA',
+      minWidth: 54,
       treeAggregationType: uiGridGroupingConstants.aggregation.SUM
     };
   };
@@ -62,7 +69,8 @@ function GridDefaults($filter, $timeout, Student, AbsenceRecord,
       displayName: 'Withdrawn',
       enableCellEdit: true,
       type: 'boolean',
-      width: 100,
+      headerTooltip: 'Withdrawn',
+      minWidth: 54,
       filter: {
         noTerm: true,
         condition: function(searchTerm, cellValue) {
@@ -83,7 +91,8 @@ function GridDefaults($filter, $timeout, Student, AbsenceRecord,
       displayName: 'Updated',
       type: 'date',
       cellFilter: 'date:\'MM/dd/yy\'',
-      width: 125
+      headerTooltip: 'Updated',
+      minWidth: 54 * 2
     };
   };
   colDefs.outreach = function(name, type, visible) {
@@ -91,7 +100,7 @@ function GridDefaults($filter, $timeout, Student, AbsenceRecord,
     return {
       name: firstWord + '.' + type,
       displayName: type === 'count' ? firstWord : _.capitalize(type),
-      minWidth: 80,
+      minWidth: 54,
       type: 'number',
       headerTooltip: name + ' ' + _.capitalize(type),
       treeAggregationType: uiGridGroupingConstants.aggregation.SUM,
@@ -158,39 +167,45 @@ function GridDefaults($filter, $timeout, Student, AbsenceRecord,
           name: 'entry.absences',
           displayName: 'Absences',
           type: 'number',
-          minWidth: 100,
+          headerTooltip: 'Absences',
+          minWidth: 54,
           treeAggregationType: uiGridGroupingConstants.aggregation.SUM
         },
         {
           name: 'entry.absencesDelta',
           displayName: 'Δ',
           type: 'number',
-          width: 50
+          headerTooltip: 'Absences Δ',
+          width: 54
         },
         {
           name: 'entry.tardies',
           displayName: 'Tardies',
           type: 'number',
-          minWidth: 100,
+          headerTooltip: 'Tardies',
+          minWidth: 54,
           treeAggregationType: uiGridGroupingConstants.aggregation.SUM
         },
         {
           name: 'entry.tardiesDelta',
           displayName: 'Δ',
           type: 'number',
-          width: 50
+          headerTooltip: 'Tardies Δ',
+          width: 54
         },
         {
           name: 'entry.present',
           displayName: 'Present',
           type: 'number',
-          minWidth: 100
+          headerTooltip: 'Present',
+          minWidth: 54
         },
         {
           name: 'entry.enrolled',
           displayName: 'Enrolled',
           type: 'number',
-          minWidth: 100
+          headerTooltip: 'Enrolled',
+          minWidth: 54
         },
         colDefs.iep(),
         colDefs.cfa(),

--- a/server/api/absence-record/absence-record.controller.js
+++ b/server/api/absence-record/absence-record.controller.js
@@ -51,13 +51,24 @@ var studentDefaults = {
   withdrawn: false
 };
 
+function createStudents(newStudents) {
+  return new Promise(function(resolve, reject) {
+    if (!newStudents.length) return resolve([]);
+    Student.insertMany(newStudents).then(function(createdStudents) {
+      return resolve(createdStudents);
+    }).catch(function(err) {
+      return reject(err);
+    });
+  });
+}
+
 /**
  * Creates a new absence record in the DB.
  * restriction: 'teacher'
  */
 exports.create = function(req, res) {
   var result = {};
-  var existingEntries = _.map(req.body.updates || [], 'entry');
+  var existingEntries = _.map(req.body.updates, 'entry');
   var newStudents = _.map(req.body.creates, 'student');
   var newEntries = _.map(req.body.creates, 'entry');
   var outreaches = [];
@@ -66,7 +77,7 @@ exports.create = function(req, res) {
     _.defaults(student, studentDefaults);
     student.school = req.school._id;
   });
-  Student.insertMany(newStudents).then(function(createdStudents) {
+  createStudents(newStudents).then(function(createdStudents) {
     // Fill in missing student for new entries.
     _.forEach(createdStudents, function(student, index) {
       newEntries[index].student = student._id;


### PR DESCRIPTION
Add header tooltips to each column definition since it is possible to resize the columns to make the headers unreadable.

This allows the user to choose resize the width of each column in the grids. It may get irritating to constantly have to resize the columns when navigating away some we probably want to implement the ui-grid's saveState feature at some point.