### PR TITLE
included missing entries

### DIFF
--- a/server/api/visualization/visualization.controller.js
+++ b/server/api/visualization/visualization.controller.js
@@ -23,7 +23,15 @@ exports.cfaComparison = function(req, res) {
   var pipeline = [{
     $sort: {date: -1}
   }, {
-    $group: {_id: '$school', entries: {$first: '$entries'}}
+    $group: {
+      _id: '$school', 
+      entries: {$first: '$entries'} , 
+      missingEntries: {$first: '$missingEntries'}
+    }
+  }, {
+    $project: {
+      entries: {$setUnion: ['$entries', '$missingEntries']}
+    }
   }, {
     $unwind: '$entries'
   }, {


### PR DESCRIPTION
@dting 

Added `$missingEntries` to the pipeline, which seems to account for the discrepancy in the visualization aggregation count. Refer to lines [34](https://github.com/child-first-authority-fcc-project/webapp/blob/master/server/api/absence-record/absence-record.list.controller.js#L34) and [42](https://github.com/child-first-authority-fcc-project/webapp/blob/master/server/api/absence-record/absence-record.list.controller.js#L42) of `absence-record.list.controller.js`