### PR TITLE
Revert buildcontrol changes

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -405,7 +405,7 @@ module.exports = function (grunt) {
       },
       heroku: {
         options: {
-          remote: 'https://git.heroku.com/childfirstauthority.git',
+          remote: 'heroku',
           branch: 'master'
         }
       },


### PR DESCRIPTION
This reverts the change for #440. We want to keep the
gruntfile agnostic to the deploy repo. In order to set
the heroku remote as the buildcontol remote the name
of the remote just needs to be heroku. Build control will
automatically use the heroku branch of the git repo in the
dist folder to deploy.

One way to accomplish this is to use heroku's toolkit to
clone the repo before running grunt buildcontrol:heroku

From the app root, Delete the dist/ folder using:
```
rm -rf dist/
```
then from the app root:

```
heroku git:clone -a <herokuappname> app
```
where `<herokuappname>` in our case is `childfirstauthority`.